### PR TITLE
Update dist target in Makefile to use main instead of master branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,4 @@ include $(PGXS)
 
 dist:
 	mkdir -p dist
-	git archive --format zip --prefix=$(EXTENSION)-$(EXTVERSION)/ --output dist/$(EXTENSION)-$(EXTVERSION).zip master
+	git archive --format zip --prefix=$(EXTENSION)-$(EXTVERSION)/ --output dist/$(EXTENSION)-$(EXTVERSION).zip main


### PR DESCRIPTION
The Makefile was referencing `master` as the main branch name which was failing given that `main` is the current default branch. This was causing the `make dist` to fail given that the `master` branch doesn't exist.