### PR TITLE
Speed up L2 distance calculation

### DIFF
--- a/distfunc.c
+++ b/distfunc.c
@@ -11,43 +11,45 @@
 #define PORTABLE_ALIGN32 __declspec(align(32))
 #endif
 
-__attribute__((target("avx2")))
+__attribute__((target("avx2,fma")))
 static dist_t l2_dist_impl_avx2(const coord_t *x, const coord_t *y, size_t n)
 {
-    coord_t PORTABLE_ALIGN32 TmpRes[sizeof(__m256) / sizeof(float)];
-    size_t qty16 = n / 16;
-    const coord_t *pEnd1 = x + (qty16 * 16);
-    const coord_t *pEnd2 = x + n;
-    __m256 diff, v1, v2;
-    __m256 sum = _mm256_set1_ps(0);
-	dist_t res;
-
-    while (x < pEnd1) {
-        v1 = _mm256_loadu_ps(x);
-        x += 8;
-        v2 = _mm256_loadu_ps(y);
-        y += 8;
-        diff = _mm256_sub_ps(v1, v2);
-        sum = _mm256_add_ps(sum, _mm256_mul_ps(diff, diff));
-
-        v1 = _mm256_loadu_ps(x);
-        x += 8;
-        v2 = _mm256_loadu_ps(y);
-        y += 8;
-        diff = _mm256_sub_ps(v1, v2);
-        sum = _mm256_add_ps(sum, _mm256_mul_ps(diff, diff));
-    }
-    _mm256_store_ps(TmpRes, sum);
-    res = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3] + TmpRes[4] + TmpRes[5] + TmpRes[6] + TmpRes[7];
-
-    // Handle case when dimensions is not aligned on 16.
-    while (x < pEnd2)
+    const size_t elts_per_vector = sizeof(__m256) / sizeof(float);
+    const size_t unroll = 2;
+    const size_t elts_per_loop = elts_per_vector * unroll;
+    float partial_result[elts_per_vector];
+    __m256 accum1 = _mm256_setzero_ps();
+    __m256 accum2 = _mm256_setzero_ps();
+    for(size_t i = 0; i < n; i += elts_per_loop)
     {
-        dist_t diff = *x++ - *y++;
-        res += diff * diff;
-    }
+        __m256 vecX1 = _mm256_loadu_ps(x + i);
+        __m256 vecY1 = _mm256_loadu_ps(y + i);
+        __m256 vecSub1 = _mm256_sub_ps(vecX1, vecY1);
+        accum1 = _mm256_fmadd_ps(vecSub1, vecSub1, accum1);
 
-	return sqrtf(res);
+        __m256 vecX2 = _mm256_loadu_ps(x + i + elts_per_vector);
+        __m256 vecY2 = _mm256_loadu_ps(y + i + elts_per_vector);
+        __m256 vecSub2 = _mm256_sub_ps(vecX2, vecY2);
+        accum2 = _mm256_fmadd_ps(vecSub2, vecSub2, accum2);
+    }
+    accum1 = _mm256_add_ps(accum1, accum2);
+    _mm256_storeu_ps(partial_result, accum1);
+    float res1 = partial_result[0] + partial_result[4];
+    float res2 = partial_result[1] + partial_result[5];
+    float res3 = partial_result[2] + partial_result[6];
+    float res4 = partial_result[3] + partial_result[7];
+    res1 += res3;
+    res2 += res4;
+    res1 += res2;
+
+    size_t tail_size = n % elts_per_loop;
+    size_t tail = n - tail_size;
+    for(int i = 0; i < tail_size; i++)
+    {
+        float dist = x[tail + i] - y[tail + i];
+        res1 += (dist * dist);
+    }
+    return sqrtf(res1);
 }
 
 static dist_t l2_dist_impl_sse(const coord_t *x, const coord_t *y, size_t n)
@@ -147,8 +149,8 @@ static dist_t (*dist_func_table[3])(coord_t const* ax, coord_t const* bx, size_t
 void hnsw_init_dist_func(void)
 {
 #ifdef __x86_64__
-    dist_func_table[DIST_L2] = __builtin_cpu_supports("avx2")
-		? l2_dist_impl_avx2 : l2_dist_impl_sse;
+    dist_func_table[DIST_L2] = (__builtin_cpu_supports("avx2") && __builtin_cpu_supports("fma"))
+        ? l2_dist_impl_avx2 : l2_dist_impl_sse;
 #else
 	dist_func_table[DIST_L2] = l2_dist_impl;
 #endif


### PR DESCRIPTION
I achieved an 11% speedup over current distance function (132ns/118ns = 0.893). I achieved this using two tricks: 
- I used FMA instruction
- I introduced a second accumulator variable to relax the loop-carried dependency. Unrolling x4 doesn't seem to have a benefit. 

Below are my benchmark results (first 3 are auto-vectorization, 4th is my implementation, 5th is the one that currently exists in pg_embedding). They reproduce reliably between runs. 

```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|              313.01 |        3,194,805.46 |    0.4% |      0.01 | `l2_distance_base`
|              159.86 |        6,255,616.61 |    0.4% |      0.01 | `l2_distance_avx2`
|              202.65 |        4,934,578.92 |    0.5% |      0.01 | `l2_distance_avx2_fma`
|              118.50 |        8,439,135.05 |    0.3% |      0.01 | `l2_distance_avx2_sasha`
|              132.15 |        7,567,092.12 |    0.2% |      0.01 | `l2_distance_avx2_pg_embedding`
```