### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,42 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04, macos-13 ]
+        postgresql: [ 14, 15 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: Homebrew/actions/setup-homebrew@master
+
+      - name: brew install postgresql
+        run: |
+          brew install ${FORMULA}
+          brew services start ${FORMULA}
+
+          echo "PG_CONFIG=$(brew --prefix ${FORMULA})/bin/pg_config" >> $GITHUB_ENV
+        env:
+          FORMULA: postgresql@${{ matrix.postgresql }}
+
+      - uses: actions/checkout@v3
+
+      - run: make
+      - run: make install
+      - run: make installcheck
+
+      - if: failure()
+        run: cat regression.diffs

--- a/test/expected/knn.out
+++ b/test/expected/knn.out
@@ -1,7 +1,7 @@
 SET enable_seqscan = off;
 CREATE TABLE t (val real[]);
 INSERT INTO t (val) VALUES ('{0,1,2}'), ('{1,2,3}'), ('{1,1,1}'), (NULL);
-CREATE INDEX ON t USING hnsw (val) WITH (dims=3, m=3);
+CREATE INDEX ON t USING disk_hnsw (val) WITH (dims=3, m=3);
 INSERT INTO t (val) VALUES (array[1,2,4]);
 explain SELECT * FROM t ORDER BY val <-> array[3,3,3];
                              QUERY PLAN                             
@@ -25,7 +25,7 @@ SELECT COUNT(*) FROM t;
      5
 (1 row)
 
-CREATE INDEX ON t USING hnsw (val ann_cos_ops) WITH (dims=3, m=3);
+CREATE INDEX ON t USING disk_hnsw (val ann_cos_ops) WITH (dims=3, m=3);
 explain SELECT * FROM t ORDER BY val <=> array[3,3,3];
                              QUERY PLAN                              
 ---------------------------------------------------------------------
@@ -42,7 +42,7 @@ SELECT * FROM t ORDER BY val <=> array[3,3,3];
  {0,1,2}
 (4 rows)
 
-CREATE INDEX ON t USING hnsw (val ann_manhattan_ops) WITH (dims=3, m=3);
+CREATE INDEX ON t USING disk_hnsw (val ann_manhattan_ops) WITH (dims=3, m=3);
 explain SELECT * FROM t ORDER BY val <~> array[3,3,3];
                              QUERY PLAN                              
 ---------------------------------------------------------------------


### PR DESCRIPTION
This PR adds GitHub Workflow, which builds (`make && make install`) and tests (`make installcheck`) the extension.

CI Matrix includes Linux (ubuntu-22.04) and macOS (Ventura 13); Postgres 14 and 15.
Postgres is installed from Homebrew since I'm the most familiar with it, and it provides a universal way for Linux and macOS.

The example of CI run on my fork:
- Failure: https://github.com/bayandin/pg_embedding/actions/runs/5720056189
- Fixed test: https://github.com/bayandin/pg_embedding/actions/runs/5720300303