### PR TITLE
Run pg_embedding locally with docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,28 @@ The `pg_embedding` extension enables the using the Hierarchical Navigable Small 
 This extension is based on [ivf-hnsw](https://github.com/dbaranchuk/ivf-hnsw) implementation of HNSW
 the code for the current state-of-the-art billion-scale nearest neighbor search system<sup>[[1]](#references)</sup>.
 
+## Run pg_embedding locally with Docker Compose
+
+Firstly, [install docker with docker-compose-plugin](https://docs.docker.com/engine/install/), then clone this repo.
+
+```bash
+git clone https://github.com/neondatabase/pg_embedding.git
+```
+
+Build the docker image.
+
+```bash
+docker compose build
+```
+
+Run docker container with docker compose.
+
+```bash
+docker compose up -d
+```
+
+You can modify docker-compose.yaml as your taste.
+
 ## Using the pg_embedding extension
 
 This section describes how to use the `pg_embedding` extension in Neon with a simple example demonstrating the required statements, syntax, and options.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3.1'
+
+services:
+  pg-embedding:
+    container_name: Postgres-Embedding
+    build: docker
+    restart: on-failure
+    ports:
+      - 5432:5432
+    volumes:
+      - ./data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: pgembedding
+      POSTGRES_PASSWORD: 1_Strong_Password
+      PGDATA: /var/lib/postgresql/data/pgdata
+      

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,10 @@ version: '3.1'
 services:
   pg-embedding:
     container_name: Postgres-Embedding
-    build: docker
+    build: 
+      context: docker
+      args:
+        PG_MAJOR_VER: 15
     restart: on-failure
     ports:
       - 5432:5432

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,13 +5,11 @@ FROM postgres:$PG_MAJOR_VER AS build
 ARG PG_MAJOR_VER
 
 RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install git build-essential postgresql-server-dev-$PG_MAJOR_VER -y
+    && apt-get install build-essential postgresql-server-dev-$PG_MAJOR_VER -y
 
-WORKDIR /workspace
+ADD https://github.com/neondatabase/pg_embedding/archive/refs/heads/main.tar.gz main.tar.gz
 
-RUN git clone https://github.com/neondatabase/pg_embedding.git \
-    && cd pg_embedding \
+RUN tar --strip-components=1 -xvf main.tar.gz \
     && make \
     && make install
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,12 @@
-ARG PG_VERSION=15
+ARG PG_MAJOR_VER=15
 
-FROM debian:stable-slim AS build
+FROM postgres:$PG_MAJOR_VER AS build
 
-ARG PG_VERSION
+ARG PG_MAJOR_VER
 
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install git build-essential postgresql-server-dev-$PG_VERSION -y
+    && apt-get install git build-essential postgresql-server-dev-$PG_MAJOR_VER -y
 
 WORKDIR /workspace
 
@@ -15,10 +15,10 @@ RUN git clone https://github.com/neondatabase/pg_embedding.git \
     && make \
     && make install
 
-FROM postgres:$PG_VERSION
+FROM postgres:$PG_MAJOR_VER
 
-COPY --from=build /usr/lib/postgresql/ /usr/lib/postgresql/
-COPY --from=build /usr/share/postgresql/ /usr/share/postgresql/
+COPY --from=build /usr/lib/postgresql /usr/lib/postgresql
+COPY --from=build /usr/share/postgresql /usr/share/postgresql
 COPY ./init-extension.sh /docker-entrypoint-initdb.d/init-extension.sh
 
 RUN chmod +x /docker-entrypoint-initdb.d/init-extension.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+ARG PG_VERSION=15
+
+FROM debian:stable-slim AS build
+
+ARG PG_VERSION
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install git build-essential postgresql-server-dev-$PG_VERSION -y
+
+WORKDIR /workspace
+
+RUN git clone https://github.com/neondatabase/pg_embedding.git \
+    && cd pg_embedding \
+    && make \
+    && make install
+
+FROM postgres:$PG_VERSION
+
+COPY --from=build /usr/lib/postgresql/ /usr/lib/postgresql/
+COPY --from=build /usr/share/postgresql/ /usr/share/postgresql/
+COPY ./init-extension.sh /docker-entrypoint-initdb.d/init-extension.sh
+
+RUN chmod +x /docker-entrypoint-initdb.d/init-extension.sh

--- a/docker/init-extension.sh
+++ b/docker/init-extension.sh
@@ -1,0 +1,3 @@
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+	CREATE EXTENSION embedding;
+EOSQL


### PR DESCRIPTION
Add Dockerfile with multi-stage build.
Add docker-compose.yaml to run pg_embedding easily.