### PR TITLE
Support Postgres 12, 13 and upcoming 16

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,8 +15,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-13 ]
-        postgresql: [ 14, 15 ]
+        os: [ ubuntu-22.04 ]
+        postgresql: [ 12, 13, 14, 15 ]
+        include:
+          - os: macos-13
+            postgresql: 15
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,15 +16,21 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04 ]
-        postgresql: [ 12, 13, 14, 15 ]
+        postgresql: [ 12, 13, 14, 15, 16 ]
         include:
           - os: macos-13
             postgresql: 15
+          - os: macos-13
+            postgresql: 16
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: Homebrew/actions/setup-homebrew@master
+
+      # TODO: Remove after postgresql@16 is available in homebrew/core
+      - if: matrix.postgresql == 16
+        run: brew tap bayandin/tap
 
       - name: brew install postgresql
         run: |
@@ -42,4 +48,4 @@ jobs:
       - run: make installcheck
 
       - if: failure()
-        run: cat regression.diffs
+        run: cat regression.diffs || true

--- a/embedding.c
+++ b/embedding.c
@@ -462,7 +462,9 @@ hnsw_build(Relation heap, Relation index, IndexInfo *indexInfo)
 static bool
 hnsw_insert(Relation index, Datum *values, bool *isnull, ItemPointer heap_tid,
 			Relation heap, IndexUniqueCheck checkUnique,
+#if PG_VERSION_NUM >= 140000
 			bool indexUnchanged,
+#endif
 			IndexInfo *indexInfo)
 {
 	ArrayType* array;
@@ -899,7 +901,9 @@ hnsw_handler(PG_FUNCTION_ARGS)
 	amroutine->amproperty = NULL;	/* TODO AMPROP_DISTANCE_ORDERABLE */
 	amroutine->ambuildphasename = NULL;
 	amroutine->amvalidate = hnsw_validate;
+#if PG_VERSION_NUM >= 140000
 	amroutine->amadjustmembers = NULL;
+#endif
 	amroutine->ambeginscan = hnsw_beginscan;
 	amroutine->amrescan = hnsw_rescan;
 	amroutine->amgettuple = hnsw_gettuple;

--- a/embedding.c
+++ b/embedding.c
@@ -108,24 +108,49 @@ _PG_init(void)
 {
 	hnsw_relopt_kind = add_reloption_kind();
 	add_int_reloption(hnsw_relopt_kind, "dims", "Number of dimensions",
-					  0, 0, INT_MAX, AccessExclusiveLock);
+					  0, 0, INT_MAX
+#if PG_VERSION_NUM >= 130000
+					  , AccessExclusiveLock
+#endif
+					  );
 	add_int_reloption(hnsw_relopt_kind, "m", "Number of neighbors of each vertex",
-					  DEFAULT_M, 0, INT_MAX, AccessExclusiveLock);
+					  DEFAULT_M, 0, INT_MAX
+#if PG_VERSION_NUM >= 130000
+					  , AccessExclusiveLock
+#endif
+					  );
 	add_int_reloption(hnsw_relopt_kind, "efconstruction", "Number of inspected neighbors during index construction",
-					  DEFAULT_EF_CONSTRUCT, 1, INT_MAX, AccessExclusiveLock);
+					  DEFAULT_EF_CONSTRUCT, 1, INT_MAX
+#if PG_VERSION_NUM >= 130000
+					  , AccessExclusiveLock
+#endif
+					  );
 	add_int_reloption(hnsw_relopt_kind, "efsearch", "Number of inspected neighbors during index search",
-					  DEFAULT_EF_SEARCH, 1, INT_MAX, AccessExclusiveLock);
+					  DEFAULT_EF_SEARCH, 1, INT_MAX
+#if PG_VERSION_NUM >= 130000
+					  , AccessExclusiveLock
+#endif
+					  );
 	hnsw_init_dist_func();
 }
 
 static void
-hnsw_build_callback(Relation index, ItemPointer tid, Datum *values,
-					bool *isnull, bool tupleIsAlive, void *state)
+hnsw_build_callback(Relation index,
+#if PG_VERSION_NUM >= 130000
+					ItemPointer tid,
+#else
+					HeapTuple hup,
+#endif
+					Datum *values, bool *isnull, bool tupleIsAlive, void *state)
 {
 	HnswIndex* hnsw = (HnswIndex*) state;
 	ArrayType* array;
 	int n_items;
 	HnswLabel u;
+
+#if PG_VERSION_NUM < 130000
+	ItemPointer tid = &hup->t_self;
+#endif
 
 	/* Skip nulls */
 	if (isnull[0])
@@ -374,10 +399,24 @@ hnsw_options(Datum reloptions, bool validate)
 		{"m", RELOPT_TYPE_INT, offsetof(HnswOptions, M)}
 	};
 
+#if PG_VERSION_NUM >= 130000
 	return (bytea *) build_reloptions(reloptions, validate,
 									  hnsw_relopt_kind,
 									  sizeof(HnswOptions),
 									  tab, lengthof(tab));
+#else
+	relopt_value *options;
+	HnswOptions *rdopts;
+	int			numoptions;
+
+	options = parseRelOptions(reloptions, validate, hnsw_relopt_kind, &numoptions);
+
+	rdopts = allocateReloptStruct(sizeof(HnswOptions), options, numoptions);
+
+	fillRelOptions((void *) rdopts, sizeof(HnswOptions), options, numoptions, validate, tab, lengthof(tab));
+
+	return (bytea *) rdopts;
+#endif
 }
 
 /*
@@ -871,7 +910,9 @@ hnsw_handler(PG_FUNCTION_ARGS)
 
 	amroutine->amstrategies = 0;
 	amroutine->amsupport = 1;
+#if PG_VERSION_NUM >= 130000
 	amroutine->amoptsprocnum = 0;
+#endif
 	amroutine->amcanorder = false;
 	amroutine->amcanorderbyop = true;
 	amroutine->amcanbackward = false;	/* can change direction mid-scan */
@@ -885,8 +926,10 @@ hnsw_handler(PG_FUNCTION_ARGS)
 	amroutine->ampredlocks = false;
 	amroutine->amcanparallel = false;
 	amroutine->amcaninclude = false;
+#if PG_VERSION_NUM >= 130000
 	amroutine->amusemaintenanceworkmem = false; /* not used during VACUUM */
 	amroutine->amparallelvacuumoptions = VACUUM_OPTION_PARALLEL_BULKDEL;
+#endif
 	amroutine->amkeytype = InvalidOid;
 
 	/* Interface functions */


### PR DESCRIPTION
The PR fixes compilation for Postgres 12 and 13 (by adding a bunch of `#if PG_VERSION_NUM ...` directives).
Since I'm not mature enough in either C or the Postgres code base, I've looked at how other extensions achieve compatibility between versions and have applied the same approach. 
I didn't add Postgres 11 because it will reach EOL quite soon, on [November 9, 2023](https://www.postgresql.org/support/versioning/).
Also, I've added CI run on the upcoming Postgres 16 release (beta-2 for now)
