### PR TITLE
Test pg_embedding with Neon on CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,3 +49,51 @@ jobs:
 
       - if: failure()
         run: cat regression.diffs || true
+
+  build-and-test-on-neon:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04 ]
+        postgresql: [ 14, 15 ]
+        include:
+          - os: macos-13
+            postgresql: 15
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: Homebrew/actions/setup-homebrew@master
+
+      - run: brew tap bayandin/tap
+
+      - name: brew install neon
+        run: |
+          brew install ${FORMULA}
+
+          echo "$(brew --prefix openssl@3)/bin" >> $GITHUB_PATH
+          echo "PG_CONFIG=$(brew ruby -e 'puts "neon-postgres".to_sym.f.pg_bin_for("v${{ matrix.postgresql }}")')/pg_config" >> $GITHUB_ENV
+
+          $(brew --prefix ${FORMULA})/bin/neon-local --version
+        env:
+          FORMULA: bayandin/tap/neon-local
+
+      - name: Start neon
+        run: |
+          neon-local start
+          neon-local tenant create --pg-version ${{ matrix.postgresql }} --set-default
+          neon-local endpoint start main --pg-version ${{ matrix.postgresql }} --pg-port 60000
+
+      - uses: actions/checkout@v3
+
+      - run: make
+      - run: make install
+      - name: make installcheck
+        run: |
+          export PGPORT=60000
+          export PGUSER=cloud_admin
+
+          make installcheck
+
+      - if: failure()
+        run: cat regression.diffs || true


### PR DESCRIPTION
This PR adds building and testing `pg_embedding` on Neon Postgres (v14 and v15 on Linux and v15 on macOS).
A pipeline uses Neon from `bayandin/tap` Homebrew tap (that I update after each release).
