### PR TITLE
Ignore bytecode and Make dependency tracking files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.so
 *.o
 *.dylib
+*.bc
+.deps/
 
 # `make installcheck` artifacts
 results/


### PR DESCRIPTION
You get these files when you have configured Postgres with `--with-llvm`
and `--enable-depend`.
