### PR TITLE
Fix macOS CI runners

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - uses: Homebrew/actions/setup-homebrew@master
 
+      - name: Workaround GitHub Actions Python issues
+        if: startsWith(matrix.os, 'macos-')
+        run: brew unlink python && brew link --overwrite python
+
       # TODO: Remove after postgresql@16 is available in homebrew/core
       - if: matrix.postgresql == 16
         run: brew tap bayandin/tap
@@ -66,6 +70,10 @@ jobs:
 
     steps:
       - uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Workaround GitHub Actions Python issues
+        if: startsWith(matrix.os, 'macos-')
+        run: brew unlink python && brew link --overwrite python
 
       - run: brew tap bayandin/tap
 


### PR DESCRIPTION
This PR fixes macOS CI runners.

Misconfigured Python linkage on GitHub actions runners itself cause the error: 
```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
Target /usr/local/bin/2to3
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.11

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.11

Possible conflicting files are:
/usr/local/bin/2to3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/2to3
/usr/local/bin/2to3-3.11 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/2to3-3.11
/usr/local/bin/idle3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/idle3
/usr/local/bin/idle3.11 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/idle3.11
/usr/local/bin/pydoc3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/pydoc3
/usr/local/bin/pydoc3.11 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/pydoc3.11
/usr/local/bin/python3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/python3
/usr/local/bin/python3-config -> /Library/Frameworks/Python.framework/Versions/3.11/bin/python3-config
/usr/local/bin/python3.11 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11
/usr/local/bin/python3.11-config -> /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11-config
```